### PR TITLE
Systemd syntax instead of sysvinit in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install -g add-to-systemd
 # add a node server to systemd (will start it on boot)
 add-to-systemd my-new-service "node server.js --port 8080"
 # lets start it right away
-service my-new-service start
+systemctl start my-new-service
 ```
 
 ## License


### PR DESCRIPTION
Ubuntu has a compatibility thing that makes `service` still work, but there's no such thing on my Arch, for instance.