### PR TITLE
support niceness setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Usage: add-to-systemd name [options] command...
 
   --user, -u  [user]      User the service will run as
   --cwd,  -c  [dir]       Set the cwd of the service (Defaults to the current directory)
+  --nice, -n  [integer]   Set the process niceness
   --env,  -e  [name=val]  Add env vars to the service
 
 ```

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ if (!name) {
   console.error()
   console.error('  --user, -u  [user]      User the service will run as')
   console.error('  --cwd,  -c  [dir]       Set the cwd of the service')
+  console.error('  --nice, -n  [integer]   Set the process niceness')
   console.error('  --env,  -e  [name=val]  Add env vars to the service')
   console.error()
   process.exit(1)
@@ -48,6 +49,7 @@ if (!fs.existsSync('/lib/systemd/system/')) {
 var opts = ''
 if (argv.user) opts += 'User=' + argv.user + '\n'
 if (argv.cwd) opts += 'WorkingDirectory=' + fs.realpathSync(argv.cwd) + '\n'
+if (argv.nice) opts += 'Nice=' + argv.nice + '\n'
 if (argv.env) {
   [].concat(argv.env).forEach(function (e) {
     opts += 'Environment=' + e + '\n'


### PR DESCRIPTION
Proposition to allow passing a value for the [`Nice` option](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Nice=).

Unsolved issue: passing negative values
```sh
add-to-systemd name --nice 10 command
# => Nice=10
add-to-systemd name --nice -10 command
# => Nice=true
```

Possible work arounds:
- find and document a way to escape the `-` so that it isn't interpreted as an option
- find a substitute character that can be `.replace`d
