### PR TITLE
Arch Linux uses a different systemd command.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 var fs = require('fs')
+var os = require('os')
 var path = require('path')
 var cp = require('child_process')
 var minimist = require('minimist')
@@ -49,7 +50,11 @@ if (!fs.existsSync('/etc/systemd/system/')) {
   process.exit(2)
 }
 
-var v = Number(cp.execSync('systemd --version').toString().trim().split('\n')[0].trim().split(' ').pop() || 0)
+var sysCmd = 'systemd'
+if (os.platform() === 'linux' && os.release().substr(-4) === 'ARCH') {
+  sysCmd = 'systemctl'
+}
+var v = Number(cp.execSync(sysCmd + ' --version').toString().trim().split('\n')[0].trim().split(' ').pop() || 0)
 
 var opts = ''
 var uopts = ''


### PR DESCRIPTION
This module works great on all of my Debian flavored machines, however on Arch installs it will fail with a command not found on `systemd`.  This is because Arch uses the `systemctl` command to manage systemd.  I added an os check looking for Arch and using `systemctl` if found. This seems to work fine for my application.  Just thought I'd bring it to your attention and offer up a PR.